### PR TITLE
Added option to hide scroll indicator.

### DIFF
--- a/src/components/ScrollIndicator/ScrollIndicator.jsx
+++ b/src/components/ScrollIndicator/ScrollIndicator.jsx
@@ -34,7 +34,7 @@ export default function ScrollIndicator({
     window.addEventListener("scroll", onScroll, { passive: true });
     return () =>
       window.removeEventListener("scroll", onScroll, { passive: true });
-  }, [determineVisibility, disabled]);
+  }, [determineVisibility, disabled, showOnce, hidden]);
 
   return (
     <div className="ScrollIndicator">


### PR DESCRIPTION
The scroll indicator should only show the first time someone is stuck in a given section. If the user returns to the same spot, the scroll indicator should not show up. This PR adds a `showOnce` prop to the `ScrollIndicator` component which allows us to conditionally make this design choice. Tested on Chrome & Safari on L and S viewports.